### PR TITLE
Use default None for aws secrets

### DIFF
--- a/7/fundamentals/fundamentals.sh
+++ b/7/fundamentals/fundamentals.sh
@@ -30,11 +30,11 @@ AWS_STORAGE_BUCKET_NAME = '{{ AWS_STORAGE_BUCKET_NAME | default('thumbor') }}'
 
 ## Secret access key for S3 to allow thumbor to store objects there.
 ## Defaults to: None
-AWS_STORAGE_S3_SECRET_ACCESS_KEY = '{{ AWS_STORAGE_S3_SECRET_ACCESS_KEY | default('') }}'
+AWS_STORAGE_S3_SECRET_ACCESS_KEY = '{{ AWS_STORAGE_S3_SECRET_ACCESS_KEY | default(None) }}'
 
 ## Access key ID for S3 to allow thumbor to store objects there.
 ## Defaults to: None
-AWS_STORAGE_S3_ACCESS_KEY_ID = '{{ AWS_STORAGE_S3_ACCESS_KEY_ID | default('') }}'
+AWS_STORAGE_S3_ACCESS_KEY_ID = '{{ AWS_STORAGE_S3_ACCESS_KEY_ID | default(None) }}'
 
 ## Endpoint URL for S3 API. Very useful for testing.
 ## Defaults to: None
@@ -64,11 +64,11 @@ AWS_RESULT_STORAGE_BUCKET_NAME = '{{ AWS_RESULT_STORAGE_BUCKET_NAME | default('t
 
 ## Secret access key for S3 to allow thumbor to store objects there.
 ## Defaults to: None
-AWS_RESULT_STORAGE_S3_SECRET_ACCESS_KEY = '{{ AWS_RESULT_STORAGE_S3_SECRET_ACCESS_KEY | default('') }}'
+AWS_RESULT_STORAGE_S3_SECRET_ACCESS_KEY = '{{ AWS_RESULT_STORAGE_S3_SECRET_ACCESS_KEY | default(None) }}'
 
 ## Access key ID for S3 to allow thumbor to store objects there.
 ## Defaults to: None
-AWS_RESULT_STORAGE_S3_ACCESS_KEY_ID = '{{ AWS_RESULT_STORAGE_S3_ACCESS_KEY_ID | default('') }}'
+AWS_RESULT_STORAGE_S3_ACCESS_KEY_ID = '{{ AWS_RESULT_STORAGE_S3_ACCESS_KEY_ID | default(None) }}'
 
 ## Endpoint URL for S3 API. Very useful for testing.
 ## Defaults to: None


### PR DESCRIPTION
Need to default to None to allow instance profiles to work.

This also aligns to the thumbor aws default https://github.com/thumbor/thumbor-aws/blob/main/thumbor.conf#L767 and whats in your comments.