### PR TITLE
add ffmpeg and opencv and remove build error packages

### DIFF
--- a/7/alpine/Dockerfile
+++ b/7/alpine/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER Michael Hirschler <michael@hirschler.me>
 RUN apk add --update --no-cache \
         cairo \
         exiftool \
+        ffmpeg \
         gifsicle \
         openjpeg-tools \
         imagemagick \
@@ -25,7 +26,6 @@ RUN apk add --update --no-cache --virtual .build-deps \
       gstreamer-dev \
       harfbuzz-dev \
       hdf5-dev \
-      lapack-dev \
       libdc1394-dev \
       libgphoto2-dev \
       libtbb-dev \
@@ -36,7 +36,7 @@ RUN apk add --update --no-cache --virtual .build-deps \
       qt5-qtbase-dev \
       vtk-dev \
       cmake \
-    	samurai \
+      samurai \
       python3-dev \
       cairo-dev \
       curl-dev \
@@ -44,7 +44,6 @@ RUN apk add --update --no-cache --virtual .build-deps \
       g++ \
       libjpeg-turbo-dev \
       libffi-dev \
-      libressl-dev \
       libwebp-dev \
       python3-dev \
       tiff-dev \

--- a/7/alpine/Dockerfile
+++ b/7/alpine/Dockerfile
@@ -49,7 +49,7 @@ RUN apk add --update --no-cache --virtual .build-deps \
       tiff-dev \
       zlib-dev \
     && pip install --no-cache numpy \
-    && pip install --no-cache-dir thumbor==7.5.2 envtpl==0.7.2 \
+    && pip install --no-cache-dir thumbor[all]==7.5.2 envtpl==0.7.2 \
     && apk del .build-deps \
     && rm -rf /var/cache/apk/* \
     && rm -rf /root/.cache

--- a/7/slim/Dockerfile
+++ b/7/slim/Dockerfile
@@ -19,9 +19,9 @@ RUN apt-get update \
         # libraries: cairosvg deps (libcairo2 is required at runtime)
         libffi-dev libcairo2 \
         # extensions
-        libjpeg-progs gifsicle \
+        libjpeg-progs gifsicle ffmpeg \
     && ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/local/lib/libboost_python310.so \
-    && pip install --user --no-cache-dir cairosvg pycurl py3exiv2 thumbor==7.5.2 envtpl==0.7.2 \
+    && pip install --user --no-cache-dir cairosvg pycurl py3exiv2 thumbor[all]==7.5.2 envtpl==0.7.2 \
     && apt-get autoremove --yes gcc g++ libffi-dev python3-dev python3-all-dev libcurl4-openssl-dev libgnutls28-dev libexiv2-dev \
     && rm -rf /var/lib/apt/lists/* \
     && chown -R thumbor:thumbor /usr/local/thumbor


### PR DESCRIPTION
I saw that in the Dockerfile that has ffmpeg-dev, but when I enable GIFV I get the warning:

```
thumbor:WARNING gifv optimizer enabled but binary FFMPEG_PATH does not exist
```

I edited the Dockerfile and added ffmpeg, I did a new build and it worked, now we have gifs being converted to MP4 and WebM. 😁

During build the packages `lapack-dev` and `libressl-dev` gave error:

```
1.860 ERROR: unable to select packages:
1.867   lapack-3.11-r2:
1.867     breaks: liblapack-0.3.23-r0[!lapack]
1.868     satisfies: lapack-dev-3.11-r2[lapack=3.11-r2]
1.871   .build-deps-20230731.204301:
1.871     masked in: cache
1.872     satisfies: world[.build-deps=20230731.204301]
```
```
50.27 ERROR: libressl-dev-3.7.3-r0: trying to overwrite usr/include/openssl/aes.h owned by openssl-dev-3.1.1-r3
```

I removed them and tested the compression of all filters: [thumbor.pdf](https://github.com/mvhirsch/thumbor-docker/files/12222197/thumbor.pdf)
Only the cover filter with gif is in error, but it also happens in the official thumbor

Add the [all] tag to thumbor to install all packages needed to support opencv. The build will take much longer. 😅