### PR TITLE
install thumbor using official requirements and add ffmpeg support

### DIFF
--- a/7/slim/Dockerfile
+++ b/7/slim/Dockerfile
@@ -19,9 +19,9 @@ RUN apt-get update \
         # libraries: cairosvg deps (libcairo2 is required at runtime)
         libffi-dev libcairo2 \
         # extensions
-        libjpeg-progs gifsicle \
+        libjpeg-progs gifsicle ffmpeg \
     && ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/local/lib/libboost_python310.so \
-    && pip install --user --no-cache-dir cairosvg pycurl py3exiv2 thumbor==7.5.2 envtpl==0.7.2 \
+    && pip install --user --no-cache-dir thumbor[all]==7.5.2 envtpl==0.7.2 \
     && apt-get autoremove --yes gcc g++ libffi-dev python3-dev python3-all-dev libcurl4-openssl-dev libgnutls28-dev libexiv2-dev \
     && rm -rf /var/lib/apt/lists/* \
     && chown -R thumbor:thumbor /usr/local/thumbor


### PR DESCRIPTION
In `Slim` version
- add `ffmpeg` package to support conversion to webm/mp4
- install all thumbor packages using `[all]` oficial tag